### PR TITLE
[DO NOT MERGE] Use logicstar compressed images for swebench verified evals

### DIFF
--- a/evaluation/benchmarks/swe_bench/run_infer.py
+++ b/evaluation/benchmarks/swe_bench/run_infer.py
@@ -170,7 +170,7 @@ logger.info(f'Default docker image prefix: {DEFAULT_DOCKER_IMAGE_PREFIX}')
 
 def get_instance_docker_image(
     instance_id: str,
-    swebench_official_image: bool = False,
+    swebench_official_image: bool = True,
 ) -> str:
     if swebench_official_image:
         # Official SWE-Bench image
@@ -179,7 +179,10 @@ def get_instance_docker_image(
         if DATASET_TYPE == 'SWE-bench-Live':
             docker_image_prefix = 'docker.io/starryzhang/'
         elif DATASET_TYPE == 'SWE-bench':
-            docker_image_prefix = 'docker.io/swebench/'
+            if os.environ.get('USE_LOGICSTAR', 'false').lower() == 'true':
+                docker_image_prefix = '10.10.100.19:5000/swebench/'
+            else:
+                docker_image_prefix = 'docker.io/swebench/'
         repo, name = instance_id.split('__')
         image_name = f'{docker_image_prefix.rstrip("/")}/sweb.eval.x86_64.{repo}_1776_{name}:latest'.lower()
         logger.debug(f'Using official SWE-Bench image: {image_name}')

--- a/evaluation/benchmarks/swe_bench/run_infer.py
+++ b/evaluation/benchmarks/swe_bench/run_infer.py
@@ -180,7 +180,7 @@ def get_instance_docker_image(
             docker_image_prefix = 'docker.io/starryzhang/'
         elif DATASET_TYPE == 'SWE-bench':
             if os.environ.get('USE_LOGICSTAR', 'false').lower() == 'true':
-                docker_image_prefix = '10.10.100.19:5000/swebench/'
+                docker_image_prefix = '10.10.100.19:5001/logicstar/'
             else:
                 docker_image_prefix = 'docker.io/swebench/'
         repo, name = instance_id.split('__')

--- a/evaluation/benchmarks/swe_bench/scripts/eval_infer.sh
+++ b/evaluation/benchmarks/swe_bench/scripts/eval_infer.sh
@@ -92,6 +92,13 @@ if [[ "$ENVIRONMENT" == "modal" ]]; then
     MODAL_FLAG="--modal true"
 fi
 
+if [ "$USE_LOGICSTAR" == "true" ]; then
+    echo "Using LogicStar compressed images for official SWE-bench verified runs"
+    export NAMESPACE=10.10.100.19:5001/logicstar
+else
+    export NAMESPACE=docker.io/swebench
+fi
+
 if [ -z "$INSTANCE_ID" ]; then
     echo "Running SWE-bench evaluation on the whole input file..."
     # Default to SWE-Bench-lite
@@ -105,6 +112,7 @@ if [ -z "$INSTANCE_ID" ]; then
         --cache_level instance \
         --max_workers $N_PROCESS \
         --run_id $RUN_ID \
+        --namespace $NAMESPACE \
         $MODAL_FLAG
 
     # get the "model_name_or_path" from the first line of the SWEBENCH_FORMAT_JSONL
@@ -153,5 +161,6 @@ else
         --cache_level instance \
         --max_workers $N_PROCESS \
         --run_id $RUN_ID \
+        --namespace $NAMESPACE \
         $MODAL_FLAG
 fi

--- a/openhands/runtime/impl/docker/containers.py
+++ b/openhands/runtime/impl/docker/containers.py
@@ -9,6 +9,7 @@ def stop_all_containers(prefix: str) -> None:
             try:
                 if container.name.startswith(prefix):
                     container.stop()
+                    container.remove(force=True)
             except docker.errors.APIError:
                 pass
             except docker.errors.NotFound:

--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -79,12 +79,12 @@ def get_runtime_image_repo_and_tag(base_image: str) -> tuple[str, str]:
 
         if ':' not in base_image:
             base_image = base_image + ':latest'
-        repo, tag = base_image.split(':')
+        repo, tag = base_image.rsplit(':', 1)
         return repo, tag
     else:
         if ':' not in base_image:
             base_image = base_image + ':latest'
-        [repo, tag] = base_image.split(':')
+        [repo, tag] = base_image.rsplit(':', 1)
 
         # Hash the repo if it's too long
         if len(repo) > 32:


### PR DESCRIPTION
- Uses smaller images (30GB instead of 200+ GB)
- Switched on with USE_LOGICSTAR env var
- Under test with k8s eval image